### PR TITLE
Fix: Unsubscribing from realtime notifications before app quits

### DIFF
--- a/App/Podlive/Application/CCNApplicationDelegate.m
+++ b/App/Podlive/Application/CCNApplicationDelegate.m
@@ -49,21 +49,22 @@
 }
 
 - (NSApplicationTerminateReply)applicationShouldTerminate:(NSApplication *)sender {
-    [PFUser.currentUser saveInBackgroundWithBlock:^(BOOL succeeded, NSError *error) {
-        if (succeeded) {
-            [PFInstallation.currentInstallation saveInBackgroundWithBlock:^(BOOL succeeded, NSError *error) {
+    [PFPush unsubscribeFromChannelInBackground:CCNParseRealtimeNotifications block:^(BOOL succeeded, NSError * _Nullable error) {
+        [PFUser.currentUser saveInBackgroundWithBlock:^(BOOL succeeded, NSError *error) {
+            if (succeeded) {
+                [PFInstallation.currentInstallation saveInBackgroundWithBlock:^(BOOL succeeded, NSError *error) {
+                    [NSApp replyToApplicationShouldTerminate:YES];
+                }];
+            }
+            else {
                 [NSApp replyToApplicationShouldTerminate:YES];
-            }];
-        }
-        else {
-            [NSApp replyToApplicationShouldTerminate:YES];
-        }
+            }
+        }];
     }];
     return NSTerminateLater;
 }
 
 - (void)applicationWillTerminate:(NSNotification *)aNotification {
-    [PFPush unsubscribeFromChannelInBackground:CCNParseRealtimeNotifications];
     
     let isAnonynousUser = [PFAnonymousUtils isLinkedWithUser:PFUser.currentUser];
     if (isAnonynousUser) {


### PR DESCRIPTION
This ensures the app only quits if the user successfully unsubscribed from the realtime notifications.